### PR TITLE
Support for version and platform

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -4,5 +4,5 @@ source 'https://github.com/jordansissel/puppet-pleaserun'
 author 'jordansissel'
 license 'Apache License, Version 2.0'
 summary 'A custom puppet type that invokes pleaserun.'
-description 'Yes. It's true.'
+description "Yes. It's true."
 project_page 'https://github.com/jordansissel/puppet-pleaserun'

--- a/README
+++ b/README
@@ -1,6 +1,18 @@
 pleaserun
 
-This is the pleaserun module.
+This is the pleaserun module
+
+```
+  pleaserun {'redis':
+    ensure   => present,
+    name     => 'redis',
+    program  => '/opt/redis/bin/redis-server',
+  } ->
+
+  service { 'redis':
+    ensure => running
+  }
+```
 
 License
 -------

--- a/README
+++ b/README
@@ -4,9 +4,11 @@ This is the pleaserun module
 
 ```
   pleaserun {'redis':
-    ensure   => present,
-    name     => 'redis',
-    program  => '/opt/redis/bin/redis-server',
+    ensure         => present,
+    name           => 'redis',
+    platform       => 'sysv',
+    target_version => 'lsb-3.1',
+    program        => '/opt/redis/bin/redis-server',
   } ->
 
   service { 'redis':

--- a/lib/puppet/feature/pleaserun.rb
+++ b/lib/puppet/feature/pleaserun.rb
@@ -1,0 +1,12 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:pleaserun) do
+  begin
+    require "pleaserun/platform/base"
+    require "pleaserun/cli"
+    require "pleaserun/detector"
+    true
+  rescue LoadError => err
+      warn "Cannot load the pleaserun gem. #{err}"
+  end
+end

--- a/lib/puppet/provider/pleaserun/default.rb
+++ b/lib/puppet/provider/pleaserun/default.rb
@@ -1,10 +1,13 @@
-require "pleaserun/platform/base"
-require "pleaserun/cli"
-require "pleaserun/detector"
 Puppet::Type.type(:pleaserun).provide(:default) do
   desc "The default and most awesome pleaserun experience."
 
-  def platform
+  confine :feature => :pleaserun
+
+  if Puppet.features.pleaserun?
+    require "pleaserun/platform/base"
+    require "pleaserun/cli"
+    require "pleaserun/detector"
+  end
 
   def runner
     return @runner if @runner

--- a/lib/puppet/provider/pleaserun/default.rb
+++ b/lib/puppet/provider/pleaserun/default.rb
@@ -4,11 +4,16 @@ require "pleaserun/detector"
 Puppet::Type.type(:pleaserun).provide(:default) do
   desc "The default and most awesome pleaserun experience."
 
+  def platform
+
   def runner
     return @runner if @runner
 
-    # XXX: Split these into separate "providers"
-    platform, version = PleaseRun::Detector.detect
+    platform = @resource[:platform]
+    version = @resource[:target_version]
+    if platform.nil? && version.nil?
+        platform, version = PleaseRun::Detector.detect
+    end
 
     # silly hack for now until I properly refactor this.
     cli = PleaseRun::CLI.new([])
@@ -18,6 +23,7 @@ Puppet::Type.type(:pleaserun).provide(:default) do
     @runner = runner_klass.new(version)
     @runner.name = @resource[:name]
     @runner.program = @resource[:program]
+    @runner.target_version = version
     # Args are optional.
     @runner.args = @resource[:args] if @resource[:args]
     return @runner

--- a/lib/puppet/provider/pleaserun/default.rb
+++ b/lib/puppet/provider/pleaserun/default.rb
@@ -4,8 +4,6 @@ require "pleaserun/detector"
 Puppet::Type.type(:pleaserun).provide(:default) do
   desc "The default and most awesome pleaserun experience."
 
-  def platform
-
   def runner
     return @runner if @runner
 

--- a/lib/puppet/type/pleaserun.rb
+++ b/lib/puppet/type/pleaserun.rb
@@ -27,6 +27,26 @@ Puppet::Type.newtype(:pleaserun) do
     end
   end
 
+  newparam(:platform) do
+    desc "The name of the platform to target, such as sysv, upstart, etc"
+
+    validate do |value|
+      if !value.is_a?(String)
+        raise ArgumentError, "Platform must be a String, not #{value.class}"
+      end
+    end
+  end
+
+  newparam(:target_version) do
+    desc "The version of the platform to target, such as 'lsb-3.1' for sysv or '1.5' for upstart"
+
+    validate do |value|
+      if !value.is_a?(String)
+        raise ArgumentError, "Version must be a String, not #{value.class}"
+      end
+    end
+  end
+
   newparam(:args) do
     desc "The arguments to pass to the program."
 
@@ -43,7 +63,7 @@ Puppet::Type.newtype(:pleaserun) do
       end
     end
 
-    
+
     munge do |value|
       if value.is_a?(String)
         [value]


### PR DESCRIPTION
Adding the work to allow the puppet type and provider to accept the platform and target_version parameters. If no parameters are passed, then the parameters will be autodetected
